### PR TITLE
HEFT V1 Implementation

### DIFF
--- a/heft.yml
+++ b/heft.yml
@@ -2,44 +2,8 @@ name: heft
 channels:
 - defaults
 dependencies:
-- blas=1.0=mkl
-- ca-certificates=2018.03.07=0
-- certifi=2018.8.24=py37_1
-- cycler=0.10.0=py37_0
-- decorator=4.3.0=py37_0
-- freetype=2.9.1=ha9979f8_1
-- icc_rt=2017.0.4=h97af966_0
-- icu=58.2=ha66f8fd_1
-- intel-openmp=2019.0=117
-- jpeg=9b=hb83a4c4_2
-- kiwisolver=1.0.1=py37h6538335_0
-- libpng=1.6.34=h79bbb47_0
-- matplotlib=2.2.3=py37hd159220_0
-- mkl=2019.0=117
-- mkl_fft=1.0.4=py37h1e22a9b_1
-- mkl_random=1.0.1=py37h77b88f5_1
-- networkx=2.1=py37_0
-- numpy=1.15.1=py37ha559c80_0
-- numpy-base=1.15.1=py37h8128ebf_0
-- openssl=1.0.2p=hfa6e2cd_0
-- pip=10.0.1=py37_0
-- pyparsing=2.2.0=py37_1
-- pyqt=5.9.2=py37ha878b3d_0
-- python=3.7.0=hea74fb7_0
-- python-dateutil=2.7.3=py37_0
-- pytz=2018.5=py37_0
-- qt=5.9.6=vc14h62aca36_0
-- setuptools=40.2.0=py37_0
-- sip=4.19.12=py37h6538335_0
-- six=1.11.0=py37_1
-- sqlite=3.24.0=h7602738_0
-- tornado=5.1=py37hfa6e2cd_0
-- vc=14=h0510ff6_3
-- vs2015_runtime=14.0.25123=3
-- wheel=0.31.1=py37_0
-- wincertstore=0.2=py37_0
-- zlib=1.2.11=h8395fce_2
-- pip:
-  - mkl-fft==1.0.4
-  - mkl-random==1.0.1
+- matplotlib=2.2.3
+- networkx=2.1
+- numpy=1.15.1
+- python=3.7.0
 

--- a/heft/gantt.py
+++ b/heft/gantt.py
@@ -1,0 +1,35 @@
+"""
+Basic implementation of Gantt chart plotting using Matplotlib
+Taken from https://sukhbinder.wordpress.com/2016/05/10/quick-gantt-chart-with-matplotlib/ and adapted as necessary (i.e. removed Date logic, etc)
+"""
+
+import matplotlib.pyplot as plt
+import matplotlib.font_manager as font_manager
+import numpy as np
+
+def ShowGanttChart(proc_schedules):
+    """
+        Given a dictionary of processor-task schedules, displays a Gantt chart generated using Matplotlib
+    """  
+    
+    processors = list(proc_schedules.keys())
+
+    ilen=len(processors)
+    pos = np.arange(0.5,ilen*0.5+0.5,0.5)
+    fig = plt.figure(figsize=(15,6))
+    ax = fig.add_subplot(111)
+    for idx, proc in enumerate(processors):
+        for job in proc_schedules[proc]:
+            ax.barh((idx*0.5)+0.5, job.end - job.start, left=job.start, height=0.3, align='center', edgecolor='black', color='white', alpha=0.95)
+            ax.text(0.5 * (job.start + job.end - len(str(job.task))-0.25), (idx*0.5)+0.5 - 0.03125, job.task, color='red', fontweight='bold', fontsize=18, alpha=0.75)
+    
+    locsy, labelsy = plt.yticks(pos, processors)
+    plt.ylabel('Processor', fontsize=16)
+    plt.xlabel('Time', fontsize=16)
+    plt.setp(labelsy, fontsize = 14)
+    ax.set_ylim(ymin = -0.1, ymax = ilen*0.5+0.5)
+    ax.set_xlim(xmin = -5)
+    ax.grid(color = 'g', linestyle = ':', alpha=0.5)
+
+    font = font_manager.FontProperties(size='small')
+    plt.show()

--- a/heft/heft.py
+++ b/heft/heft.py
@@ -124,6 +124,7 @@ def generate_argparser():
     parser = argparse.ArgumentParser(description="A tool for finding HEFT schedules for given DAG task graphs")
     parser.add_argument("dag_file", help="File to read input DAG from", type=str)
     parser.add_argument("-l", "--loglevel", help="The log level to be used in this module. Default: INFO", type=str, dest="loglevel", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], default="INFO")
+    parser.add_argument("--showGraph", help="Switch used to enable graph display with matplotlib", dest="showGraph", action="store_true")
     return parser
 
 if __name__ == "__main__":
@@ -133,5 +134,5 @@ if __name__ == "__main__":
     logging.basicConfig(format="%(levelname)8s : %(name)16s : %(message)s", level=logging.getLevelName(args.loglevel))
 
     heftEnv = HEFT_Environment()
-    dag = readDagMatrix(args.dag_file, False)
+    dag = readDagMatrix(args.dag_file, args.showGraph)
     heftEnv.schedule_dag(dag)

--- a/heft/heft.py
+++ b/heft/heft.py
@@ -1,6 +1,7 @@
 """Core code to be used for scheduling a given DAG"""
 
-from collections import deque
+from collections import deque, namedtuple
+from math import inf
 
 import argparse
 import logging
@@ -11,9 +12,11 @@ import networkx as nx
 
 logger = logging.getLogger('heft')
 
+ScheduleEvent = namedtuple('ScheduleEvent', 'task start end')
+
 class HEFT_Environment:
     """
-    An object representing a HEFT environment. Consists of all features that are relevant for scheduling an arbitrary DAG G
+    An object representing a HEFT environment. Consists of all features that are relevant for scheduling an arbitrary DAG
     """
 
     """
@@ -46,6 +49,9 @@ class HEFT_Environment:
     def __init__(self, computation_matrix=W0, communication_matrix=C0):
         self.computation_matrix = computation_matrix
         self.communication_matrix = communication_matrix
+        self.job_schedules = {}
+        for i in range(1, len(self.computation_matrix)+1):
+            self.job_schedules[i] = None
 
     def compute_ranku(self, dag, terminal_node):
         nx.set_node_attributes(dag, { terminal_node: np.mean(self.computation_matrix[terminal_node-1]) }, "ranku")
@@ -60,13 +66,20 @@ class HEFT_Environment:
                 val = float(dag[node][succnode]['weight']) + dag.nodes()[succnode]['ranku']
                 if val > max_successor_ranku:
                     max_successor_ranku = val
-            assert max_successor_ranku > 0, "Expected maximum successor ranku to be greater than 0 but was %r" % max_successor_ranku
+            assert max_successor_ranku > 0, "Expected maximum successor ranku to be greater than 0 but was %s" % max_successor_ranku
             nx.set_node_attributes(dag, { node: np.mean(self.computation_matrix[node-1]) + max_successor_ranku }, "ranku")
 
             visit_queue.extendleft([prednode for prednode in dag.predecessors(node) if prednode not in visit_queue])
         
         for node in dag.nodes():
             logger.info("Node: %s, Rank U: %s" % (node, dag.nodes()[node]['ranku']))
+
+    def compute_eft(self, dag, node, proc):
+        readytime = 0
+        for prednode in dag.predecessors(node):
+            assert self.job_schedules[prednode] != None, "Predecessor nodes must be scheduled before their children"
+            readytimetemp = self.job_schedules[prednode].end + self.communication_matrix
+
 
     def schedule_dag(self, dag):
         # Nodes with no successors cause the any expression to be empty
@@ -78,7 +91,12 @@ class HEFT_Environment:
 
         sorted_nodes = sorted(dag.nodes(), key=lambda node: dag.nodes()[node]['ranku'], reverse=True)
         for node in sorted_nodes:
-            minEFT = sys.maxsize
+            minTaskSchedule = ScheduleEvent(node, inf, inf)
+            for proc in range(1, len(self.computation_matrix[node-1])+1):
+                taskschedule = self.compute_eft(dag, node, proc)
+                if (taskschedule.end < minTaskSchedule.end):
+                    minTaskSchedule = taskschedule
+            self.job_schedules[proc].append(minTaskSchedule)
             #for p in range(len(self.computation_matrix[node-1])):
             #TODO: Implement EFT(ni, pk) using insertion-based scheduling policy
 
@@ -93,7 +111,7 @@ def readDagMatrix(dag_file, show_dag=False):
             # All edges with weight of 0
             [edge for edge in dag.edges() if dag.get_edge_data(*edge)['weight'] == '0']
         )
-        # Change 0-based node indexing to 1-based
+        # Change 0-based node labels to 1-based
         dag = nx.relabel_nodes(dag, dict(map(lambda node: (node, node+1), list(dag.nodes()))))
 
         if show_dag:

--- a/heft/heft.py
+++ b/heft/heft.py
@@ -117,7 +117,7 @@ class HEFT_Environment:
             predjob = self.task_schedules[prednode]
             assert predjob != None, f"Predecessor nodes must be scheduled before their children, but node {node} has an unscheduled predecessor of {predjob}"
             logger.debug(f"\tLooking at predecessor node {prednode} with job {predjob} to determine ready time")
-            ready_time_t = predjob.end + self.communication_matrix[predjob.proc-1, proc-1]
+            ready_time_t = predjob.end + self.communication_matrix[predjob.proc-1, proc-1] * float(dag[predjob.task][node]['weight'])
             if ready_time_t > ready_time:
                 ready_time = ready_time_t
         if ready_time == 0:

--- a/test/graph.config
+++ b/test/graph.config
@@ -1,0 +1,21 @@
+#Resource count (RC 3)
+RC 3
+#graph height (GH 6) 
+GH 5
+#task count (TC 20)
+TC 10
+#average out_degree (AOD 2)
+AOD 2
+#communication to computation ratio (CCR 2.0)
+CCR 0.2
+#Heterogenity factor (HF 0.5)
+# 0 <= HF < 1
+HF 0.5
+
+#Communication data packet range (CDR 10 100)
+CDR 10 100
+#Link Bandwidth range (LBW 10 100)
+LBW 10 100
+
+#RANDOM seed value SEED
+SEED 9000

--- a/test/graph_gen.py
+++ b/test/graph_gen.py
@@ -1,0 +1,351 @@
+from graphviz import Digraph
+from graphviz import render
+import numpy as np
+import random as rndm
+import copy
+import csv
+class graph_node:
+	def __init__ (self, task_id, level,out_count):
+		self.outgoing_edge_count =out_count 
+		self.outgoing_edge_node = []
+		self.outgoing_edge_weight = []
+		self.level = level
+		self.task_id = task_id
+		self.resource_exe_time = []
+def split_number(number, parts):
+	count_per_part = []
+	while len(count_per_part) == 0 :
+	        for i in range( parts-1):
+        	        tmp1 = (number-sum(count_per_part))/(parts - i)
+                	tmp2 = 0
+	                while tmp2<=0:
+        	                tmp2 = int(rndm.normalvariate(tmp1, tmp1/2))
+                	count_per_part.extend([tmp2])
+
+	        count_per_part.extend([number-sum(count_per_part)])
+        	#print "MIN", min(count_per_part)
+	        if min(count_per_part) <= 0 :
+        	        count_per_part = []
+                	print "sampling error"
+	return count_per_part
+resource_count = 3
+graph_height = 6
+vertex_count = 20
+mean_outdeg = 2
+sd_outdeg = 1
+comm_2_comp = 2.0
+HF = 0.5
+edge_weight_range = [1,100]
+bw_range = [10,100]
+
+with open("graph.config","r") as f:
+	config = f.readlines()
+config = [(x.strip()).split() for x in config]
+#print config
+SEED = 1000
+for x in config:
+	#print x
+	if len(x) == 0:
+		continue
+	if    x[0] == "RC": resource_count = int(x[1])
+	elif  x[0] == "GH": graph_height = int(x[1])
+	elif  x[0] == "TC": vertex_count = int(x[1])
+	elif  x[0] == "AOD": mean_outdeg = int(x[1])
+	elif  x[0] == "CCR": comm_2_comp = float(x[1])
+	elif  x[0] == "HF": HF = float(x[1])
+	elif  x[0] == "CDR": edge_weight_range = [float(x[1]), float(x[2])]
+	elif  x[0] == "LBW": bw_range = [float(x[1]), float(x[2])]
+	elif  x[0] == "SEED": SEED = int(x[1])
+	
+
+
+
+
+
+
+if (HF <0) or (HF>1):
+	print "0 <= (Heterogenity Factor(HF)) < 1"
+	exit()
+vertex_count = vertex_count
+graph_height = graph_height
+
+
+np.random.seed(SEED)
+rndm.seed(SEED)
+print "SEED=", SEED
+nodes_list = []
+if vertex_count< graph_height:
+	print "Number of nodes are smaller than graph height"
+	exit()
+resource_com_bw = np.zeros((resource_count,resource_count))
+#set communication bandwidth among resources
+for i in range(resource_count):
+	for j in range(i+1):
+		if i == j:
+			continue
+		else:
+			resource_com_bw[i][j] = rndm.randint(bw_range[0],bw_range[1])
+			resource_com_bw[j][i] = resource_com_bw[i][j] 
+
+
+
+
+#print resource_com_bw
+#start with one node in the graph
+node_count_per_level = [1]
+#number of nodes per level
+node_count_per_level.extend(split_number(vertex_count-2,graph_height-2))
+#end with one node in the graph
+node_count_per_level.extend([1])
+
+
+
+#print node_count_per_level
+#print sum(node_count_per_level)
+
+level_nodes_list = []
+count = 0
+#connect nodes in adjacent level
+#assign the number of edges (to each node) in each level to connect with adjacent level
+for level in range(len(node_count_per_level)):
+	tmp1 = []
+	elem = node_count_per_level[level]
+	out_edge_count_to_next_level = []
+	if level != len(node_count_per_level) -1 :
+		if elem > node_count_per_level[level+1]	:
+			out_edge_count_to_next_level = split_number(elem,elem)
+		else :
+			out_edge_count_to_next_level = split_number(node_count_per_level[level+1] , elem)
+	else:
+		out_edge_count_to_next_level = list(np.zeros((elem)))
+	#print "OUT",out_edge_count_to_next_level
+		
+	for i in range(elem):
+		tmp1.extend([graph_node(count, level, int(out_edge_count_to_next_level[i]))])
+		count = count + 1
+	for elem1 in tmp1:
+		nodes_list.extend([elem1])
+	level_nodes_list.append(tmp1)	
+#for level in range(len(level_nodes_list)):	
+#	print "Level", level
+#	for elem in level_nodes_list[level]:
+#		print elem.task_id, elem.level, elem.outgoing_edge_count
+
+tmp = 0
+#make actual connections among the nodes in adjacent levels
+while tmp != graph_height:
+	l1 = []
+	l0 = []
+
+	for elem in nodes_list:
+		if elem.level == tmp+1:
+			l1.extend([elem.task_id])
+		if elem.level == tmp:
+			l0.extend([elem.task_id])
+		
+	l1_tmp = copy.deepcopy(l1)
+	for elem in l0:
+		for elem1 in range(nodes_list[elem].outgoing_edge_count):
+			tmp1 = rndm.choice(l1_tmp) 
+			nodes_list[elem].outgoing_edge_node.extend([tmp1])
+			nodes_list[elem].outgoing_edge_weight.extend([rndm.randint(edge_weight_range[0], edge_weight_range[1])])
+			l1_tmp.remove(tmp1)
+			if len(l1_tmp)	== 0:
+				#print "EMPTY"
+				l1_tmp = copy.deepcopy(l1)
+	tmp =tmp + 1				
+		
+
+##add more edges to each node to ensure the connections among multiple levels
+for elem in nodes_list:
+	if ((elem.level == (graph_height-1)) or (elem.level == (graph_height-2)) or (elem.level == 0)):
+		continue
+	current_node_level = elem.level
+	remaining_nodes = 0
+	l1 = []
+	for elem1 in nodes_list:
+		if elem1.level > elem.level:
+			l1.extend([elem1.task_id])
+	for elem1 in elem.outgoing_edge_node :
+		l1.remove(elem1)
+	remaining_nodes = len(l1)
+	tmp1 = 0
+	while (tmp1 <= 0) or (tmp1 > remaining_nodes) :
+		tmp1 = int(np.random.normal(mean_outdeg, sd_outdeg))
+	if (elem.outgoing_edge_count >= tmp1):
+		continue
+	#if elem.level != (graph_height-2)	
+
+	#pmean = 2.0/ (float(graph_height - elem.level - 1 ))
+	#print "pmean", pmean
+	new_nodes_to_connect = []
+	for i in range (tmp1 - elem.outgoing_edge_count):
+		tmp2 = rndm.choice(l1)	
+		l1.remove(tmp2)
+		new_nodes_to_connect.extend([tmp2])
+		'''
+		dist_level = 0
+		while dist_level<=0 or dist_level > (graph_height-elem.level-1) :
+			dist_level = np.random.geometric(pmean)
+			#print  "pmean",pmean, dist_level, elem.level
+		dist_level = dist_level + elem.level  
+		print "pmean1", tmp1, elem.outgoing_edge_count, pmean, dist_level, elem.level
+		'''
+		'''
+		l1 = []
+		for elem2 in nodes_list:
+			if elem2.level == dist_level:
+				l1.extend([elem2.task_id])
+		tmp2 = rndm.choice(l1)
+		new_nodes_to_connect.extend([tmp2])
+		'''
+	elem.outgoing_edge_count = elem.outgoing_edge_count + len(new_nodes_to_connect)
+	for elem1 in new_nodes_to_connect :
+		elem.outgoing_edge_node.extend([elem1])
+		elem.outgoing_edge_weight.extend([rndm.randint(1,100)])
+		
+			
+
+link_bw = [] 
+for i in range(len(resource_com_bw)):	
+	for j in range(len(resource_com_bw[i])):
+		print i, j
+		if (i==j):
+			break
+		else:
+			link_bw.extend([resource_com_bw[i][j]])
+
+print link_bw
+
+#assign computation time to each node on different resources
+for elem in nodes_list:
+	#find maximum data transfer
+	max_weight = -1
+	if elem.outgoing_edge_count == 0:
+		#if node has no outgoin edge then assign random value to communication time to calculate computation time later
+		average_com_time = float(rndm.randint(edge_weight_range[0], edge_weight_range[1]))/ float(rndm.randint(bw_range[0],bw_range[1]))
+	else :
+		for tmp in elem.outgoing_edge_weight:
+			if tmp > max_weight:
+				max_weight = tmp
+
+		com_time= [float(max_weight)/float(bw) for bw in link_bw]
+		average_com_time = sum(com_time)/float(len(com_time))
+		
+	mean_comp_time = float(average_com_time) / float(comm_2_comp)
+	resource_count = len(resource_com_bw) 
+	exe_time = []
+	if HF==0:
+		exe_time = [mean_comp_time for et in range(resource_count)]
+	else:
+		lb = mean_comp_time - (HF*mean_comp_time)
+		ub = mean_comp_time + (HF*mean_comp_time)
+		exe_time = np.random.uniform(lb,ub, resource_count)
+
+	elem.resource_exe_time = exe_time	
+		
+			
+	
+connect_matrix = np.zeros((len(nodes_list), len(nodes_list)))
+for elem in nodes_list:
+	for elem1 in range(len(elem.outgoing_edge_node)):
+		connect_matrix[elem.task_id][elem.outgoing_edge_node[elem1]] = elem.outgoing_edge_weight[elem1]
+
+#print connect_matrix
+
+		
+			
+			
+			
+
+		
+
+	
+
+	
+			
+for level in range(len(level_nodes_list)):	
+	print "Level", level
+	for elem in level_nodes_list[level]:
+		print elem.task_id, elem.level, elem.outgoing_edge_count, elem.outgoing_edge_node, elem.outgoing_edge_weight, elem.resource_exe_time
+#print len(nodes_list)
+
+
+##write resource to resource bandwidth
+
+resource_count = len(resource_com_bw) 
+
+tmp = ["P_"+str(i) for i in range(resource_count)]
+tmp.insert(0, "P")
+write_data = [tmp]
+for i in range(resource_count):
+	tmp = ["P_" + str(i)]		
+	for j in range(resource_count):
+		tmp.extend([resource_com_bw[i][j]])
+	write_data.append(tmp)
+#print write_data
+with open("resource_BW.csv", "wb") as f:
+    writer = csv.writer(f)
+    writer.writerows(write_data)
+###write connectivity matrix with data transfer size
+
+task_count = len(connect_matrix)
+tmp = ["T_"+str(i) for i in range(task_count)]
+tmp.insert(0, "T")
+write_data = [tmp]
+for i in range(task_count):
+        tmp = ["T_" + str(i)]
+        for j in range(task_count):
+                tmp.extend([connect_matrix[i][j]])
+        write_data.append(tmp)
+#print write_data
+with open("task_connectivity.csv", "wb") as f:
+    writer = csv.writer(f)
+    writer.writerows(write_data)
+
+##write execution time matrix
+resource_count = len(resource_com_bw)
+tmp = ["P_"+str(i) for i in range(resource_count)]
+tmp.insert(0, "TP")
+write_data = [tmp]
+task_count = len(connect_matrix)
+for i in range(len(nodes_list)):
+	tmp = ["T_" + str(i)]
+	for j in range(resource_count):
+		tmp.extend([nodes_list[i].resource_exe_time[j]])
+	write_data.append(tmp)
+with open("task_exe_time.csv", "wb") as f:
+    writer = csv.writer(f)
+    writer.writerows(write_data)
+
+
+
+
+
+
+
+
+#exit()	
+	
+
+
+
+
+dot = Digraph()
+for elem in nodes_list:	
+	#dot.node('t'+str(elem.task_id), 't'+str(elem.task_id))
+	dot.node('T_'+str(elem.task_id))
+edges = []
+for elem in nodes_list:
+	for elem1 in elem.outgoing_edge_node:
+		#edges.extend(['t'+str(elem.task_id)+'t'+str(nodes_list[elem1].task_id)])	
+		dot.edge('T_'+str(elem.task_id), 'T_'+str(nodes_list[elem1].task_id))	
+#dot.edges(edges)	
+file_name= "/home/nirmalk/Documents/DASH_sim/graph_gen/graph_plot.gv"
+dot.render( file_name, view=True) 			
+#render('dot', 'png', file_name) 			
+
+
+
+#print level_nodes_list
+


### PR DESCRIPTION
Core changes:
- Adds the ability to calculate EFT of a particular job using an "insertion based" scheduling policy
- Therefore adds the ability to schedule based on the minimum EFT of a particular job to a particular processor
- Therefore completes the first full implementation of HEFT along with a recreation of the example from the paper
- Includes the ability to visualize a generated schedule as a Gantt chart using the `--showGantt` flag

Quality of Life:
- Improves INFO/DEBUG logging, logger configuration, etc with more informative messages, better formatted data structures, and so on
- Vastly simplifies the environment YML by manually trimming down what `conda env export` produced after realizing it wasn't very useful in that state
- Refactored some of the method names to better reflect their status as "public" or "private" methods
- Added CLI flag for whether or not to display the computational task DAG after parsing it in from the input file
- Adds a vendored implementation of a graph generation framework for use in generating further test data
